### PR TITLE
Fix missing attribute in Kafka listener

### DIFF
--- a/06_uns_kafka/src/uns_kafka/uns_kafka_listener.py
+++ b/06_uns_kafka/src/uns_kafka/uns_kafka_listener.py
@@ -58,6 +58,10 @@ class UNSKafkaMapper:
         self.kafka_handler: KafkaHandler = KafkaHandler(
             KAFKAConfig.kafka_config_map)
 
+        # store ignored mqtt attributes for filtering when converting
+        # payloads to dictionaries
+        self.mqtt_ignored_attributes = MQTTConfig.ignored_attributes
+
         self.uns_client.run(
             host=MQTTConfig.host,
             port=MQTTConfig.port,


### PR DESCRIPTION
## Summary
- initialize `mqtt_ignored_attributes` in `UNSKafkaMapper`

## Testing
- `ruff check --output-format=github --select=E9,F63,F7,F82 .`
- `ruff check --output-format=github --exit-zero .`
- `uv run pytest -m "not integrationtest"`

------
https://chatgpt.com/codex/tasks/task_e_6840da2126bc83259c547ebe3cc7beea