### PR TITLE
Fix docstring in Kafka listener test

### DIFF
--- a/06_uns_kafka/test/test_uns_kafka_listner.py
+++ b/06_uns_kafka/test/test_uns_kafka_listner.py
@@ -200,7 +200,7 @@ def get_kafka_consumer(kafka_producer_config: dict) -> Consumer:
 
 def check_kafka_topics(mqtt_client, kafka_listener, expected_kafka_msg):
     """
-    Checks the kafka topic for teh expected message
+    Checks the Kafka topic for the expected message.
     """
     try:
         while True:


### PR DESCRIPTION
## Summary
- update check_kafka_topics docstring

## Testing
- `ruff check test/test_uns_kafka_listner.py`
- `ruff check .`
- `pytest -k "" -m "not integrationtest" -q test/test_uns_kafka_listner.py` *(fails: ModuleNotFoundError: No module named 'uns_mqtt')*

------
https://chatgpt.com/codex/tasks/task_e_6840dcb7a5cc8325875a0ce9a50ce53f