### PR TITLE
Handle unset HistorianDBPool when closing

### DIFF
--- a/07_uns_graphql/src/uns_graphql/backend/historian.py
+++ b/07_uns_graphql/src/uns_graphql/backend/historian.py
@@ -86,11 +86,15 @@ class HistorianDBPool:
         """
         Close the connection pool
         """
+        if cls._shared_pool is None:
+            LOGGER.warning("Connection pool is not initialized")
+            return
+
         if not cls._shared_pool.is_closing():
             await cls._shared_pool.close()
             LOGGER.info("Connection pool closed successfully")
         else:
-            LOGGER.warning("Connection pool was already closed ")
+            LOGGER.warning("Connection pool was already closed")
 
     async def __aenter__(self):
         self._pool: Pool = await self.get_shared_pool()  # Acquire the shared pool directly

--- a/07_uns_graphql/test/backend/test_historian.py
+++ b/07_uns_graphql/test/backend/test_historian.py
@@ -186,3 +186,14 @@ async def test_get_historic_events_for_property_keys(
             to_datetime=to_timestamp,
         )
         assert len(result) == count_of_return
+
+
+@pytest.mark.asyncio()
+async def test_close_pool_without_creation_does_not_raise():
+    """Calling close_pool without creating the pool should not raise."""
+    saved_pool = HistorianDBPool._shared_pool
+    HistorianDBPool._shared_pool = None
+    try:
+        await HistorianDBPool.close_pool()
+    finally:
+        HistorianDBPool._shared_pool = saved_pool


### PR DESCRIPTION
## Summary
- prevent `close_pool` from raising when pool was never created
- add regression test for closing pool without creation

## Testing
- `pytest 07_uns_graphql/test/backend/test_historian.py::test_close_pool_without_creation_does_not_raise -q -o addopts=''`

------
https://chatgpt.com/codex/tasks/task_e_6840dcc70c7483259ad1ce28c6ba5a31