### PR TITLE
Fix docstring typo

### DIFF
--- a/02_mqtt-cluster/src/uns_sparkplugb/uns_spb_helper.py
+++ b/02_mqtt-cluster/src/uns_sparkplugb/uns_spb_helper.py
@@ -585,9 +585,7 @@ class SpBMessageGenerator:
         return metric.dataset_value
 
     def _add_row_to_dataset(self, dataset_value: Payload.DataSet, values: list[int | float | bool | str]):
-        """
-        Private Helper method to set the row in the the dataset
-        """
+        """Private helper method to set the row in the dataset."""
         ds_row = dataset_value.rows.add()
         types = dataset_value.types
         for cell_value, cell_type in zip(values, types, strict=True):


### PR DESCRIPTION
## Summary
- fix minor docstring typo in `uns_spb_helper`

## Testing
- `uv run pytest` *(fails: Connect to ipv6#[::1]:9092 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6840dd1755248325914fbe746f855d60